### PR TITLE
Fixes bug with overwritten <pre> tags

### DIFF
--- a/lib/wpautop.js
+++ b/lib/wpautop.js
@@ -48,21 +48,20 @@ function wpautop(pee, br) {
     var last_pee = phpjs.array_pop(pee_parts);
     pee = '';
     pee_parts.forEach(function(pee_part, index) {
-      var pee_iteration = '';
       var start = phpjs.strpos(pee_part, '<pre');
 
       // Malformed html?
       if ( start === false ) {
-        pee_iteration += pee_part;
+        pee += pee_part;
         return;
       }
 
       var name = "<pre wp-pre-tag-" + index + "></pre>";
       pre_tags[name] = phpjs.substr( pee_part, start ) + '</pre>';
-      pee_iteration = phpjs.substr( pee_part, 0, start ) + name;
+      pee += phpjs.substr( pee_part, 0, start ) + name;
 
-      pee += pee_iteration;
     });
+
     pee += last_pee;
   }
 

--- a/lib/wpautop.js
+++ b/lib/wpautop.js
@@ -48,18 +48,20 @@ function wpautop(pee, br) {
     var last_pee = phpjs.array_pop(pee_parts);
     pee = '';
     pee_parts.forEach(function(pee_part, index) {
+      var pee_iteration = '';
       var start = phpjs.strpos(pee_part, '<pre');
 
       // Malformed html?
       if ( start === false ) {
-        pee += pee_part;
+        pee_iteration += pee_part;
         return;
       }
 
       var name = "<pre wp-pre-tag-" + index + "></pre>";
       pre_tags[name] = phpjs.substr( pee_part, start ) + '</pre>';
-      pee = phpjs.substr( pee_part, 0, start ) + name;
+      pee_iteration = phpjs.substr( pee_part, 0, start ) + name;
 
+      pee += pee_iteration;
     });
     pee += last_pee;
   }

--- a/test/wpautop.js
+++ b/test/wpautop.js
@@ -320,7 +320,7 @@ describe('wpautop', function() {
 
   it('should not choke on an alternating set of <pre> and <div> tags', function() {
     var content  = "<div>div 1</div><pre>pre 1</pre><div>div 2</div><pre>pre 2</pre><div>div 3</div><pre>pre 3</pre><div>div 4</div><pre>pre 4</pre>";
-    var expected = "<div>div 1</div><pre>pre 1</pre><div>div 2</div><pre>pre 2</pre><div>div 3</div><pre>pre 3</pre><div>div 4</div><pre>pre 4</pre>";
+    var expected = "<div>div 1</div>\n<pre>pre 1</pre>\n<div>div 2</div>\n<pre>pre 2</pre>\n<div>div 3</div>\n<pre>pre 3</pre>\n<div>div 4</div>\n<pre>pre 4</pre>";
 
     phpjs.trim(wpautop(content)).should.be.eql(expected);
   });


### PR DESCRIPTION
The issue with several `<pre>` tags stems from the variable being overwritten every time the loop iterated, which explains why only the last `<pre>` tag persisted in the output. This wasn't a problem for most test cases, as they only made sure 1 `<pre>` tag behaved like it was meant to.
