### PR TITLE
Removed dependency on phpjs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 node_js:
   - "node"
   - "lts/*"
-  - "0.11"
-  - "0.12"
   - "4"
   - "5"
   - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: node_js
 node_js:
+  - "node"
+  - "lts/*"
   - "0.11"
   - "0.12"
   - "4"
   - "5"
   - "6"
-before_install: npm install -g mocha
+  - "7"
+  - "8"
+  - "9"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,230 @@
+{
+  "name": "wpautop",
+  "version": "0.2.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "should": {
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/should/-/should-4.6.5.tgz",
+      "integrity": "sha1-DRI0bbvRsCj59Lt6nVRzZPw2qH8=",
+      "dev": true,
+      "requires": {
+        "should-equal": "0.3.1",
+        "should-format": "0.0.7",
+        "should-type": "0.0.4"
+      }
+    },
+    "should-equal": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.3.1.tgz",
+      "integrity": "sha1-vY6pemdI45+tR2o75v1y68LnK/A=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.0.4"
+      }
+    },
+    "should-format": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.0.7.tgz",
+      "integrity": "sha1-Hi74a9kdqcLgQSM1tWq6vZov3hI=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.0.4"
+      }
+    },
+    "should-type": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.0.4.tgz",
+      "integrity": "sha1-ATKgVBemEmhmQmrPEW8e1WI6XNA=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "2.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "wpautop",
   "version": "0.2.2",
+  "engines": {
+    "node": ">= 4"
+  },
   "description": "Node.js port of Wordpress' wpautop() function",
   "main": "lib/wpautop.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,7 @@
   },
   "homepage": "https://github.com/andymantell/node-wpautop",
   "devDependencies": {
-    "mocha-jshint": "0.0.9",
+    "mocha": "^4.1.0",
     "should": "^4.6.2"
-  },
-  "dependencies": {
-    "phpjs": "^1.3.2"
   }
 }

--- a/test/jshint.js
+++ b/test/jshint.js
@@ -1,1 +1,0 @@
-// require('mocha-jshint')();

--- a/test/wpautop.js
+++ b/test/wpautop.js
@@ -1,7 +1,6 @@
 var should = require('should');
 var fs = require('fs');
 var path = require('path');
-var phpjs = require('phpjs');
 
 var wpautop = require('../lib/wpautop');
 
@@ -73,7 +72,7 @@ describe('wpautop', function() {
     var expected = content.join("\n");
     content = content.join("\n\n"); // WS difference
 
-    phpjs.trim(wpautop(content)).should.be.eql(expected);
+    wpautop(content).trim().should.be.eql(expected);
   });
 
   it('should treat inline HTML elements as inline', function() {
@@ -117,7 +116,7 @@ describe('wpautop', function() {
     content = content.join("\n\n");
     expected = expected.join("\n");
 
-    phpjs.trim(wpautop(content)).should.be.eql(expected);
+    wpautop(content).trim().should.be.eql(expected);
   });
 
   it('should not alter the contents of "<pre>" elements', function() {
@@ -125,29 +124,28 @@ describe('wpautop', function() {
 
     var code = fs.readFileSync(path.resolve(fixtures, 'sizzle.js'), {encoding: 'UTF-8'});
     code = code.replace( "\r", '', code );
-    code = phpjs.htmlentities(code);
 
     // Not wrapped in <p> tags
     str = '<pre>' + code + '</pre>';
-    phpjs.trim(wpautop(str)).should.be.eql(str);
+    wpautop(str).trim().should.be.eql(str);
 
     // Text before/after is wrapped in <p> tags
     str = 'Look at this code\n\n<pre>' + code + '</pre>\n\nIsn\'t that cool?';
 
     // Expected text after wpautop
     expected = '<p>Look at this code</p>' + "\n<pre>" + code + "</pre>\n" + '<p>Isn\'t that cool?</p>';
-    phpjs.trim(wpautop(str)).should.be.eql(expected);
+    wpautop(str).trim().should.be.eql(expected);
 
     // Make sure HTML breaks are maintained if manually inserted
     str = "Look at this code\n\n<pre>Line1<br />Line2<br>Line3<br/>Line4\nActual Line 2\nActual Line 3</pre>\n\nCool, huh?";
     expected = "<p>Look at this code</p>\n<pre>Line1<br />Line2<br>Line3<br/>Line4\nActual Line 2\nActual Line 3</pre>\n<p>Cool, huh?</p>";
-    phpjs.trim(wpautop(str)).should.be.eql(expected);
+    wpautop(str).trim().should.be.eql(expected);
 
   });
 
   it('should not add <br/> to "<input>" elements', function() {
     var str = 'Username: <input type="text" id="username" name="username" /><br />Password: <input type="password" id="password1" name="password1" />';
-    phpjs.trim(wpautop(str)).should.eql('<p>' + str + '</p>');
+    wpautop(str).trim().should.eql('<p>' + str + '</p>');
   });
 
   it('should not add <p> and <br/> around <source> and <track>', function() {
@@ -227,9 +225,9 @@ describe('wpautop', function() {
       "[/video]</p>\n" +
       '<p>Paragraph two.</p>';
 
-    phpjs.trim(wpautop(content)).should.be.eql(expected);
-    phpjs.trim(wpautop(content2)).should.be.eql(expected);
-    phpjs.trim(wpautop(shortcode_content)).should.be.eql(shortcode_expected);
+    wpautop(content).trim().should.be.eql(expected);
+    wpautop(content2).trim().should.be.eql(expected);
+    wpautop(shortcode_content).trim().should.be.eql(shortcode_expected);
 
   });
 
@@ -302,27 +300,27 @@ describe('wpautop', function() {
       "</object></div>\n" +
       '<p>Paragraph two.</p>';
 
-    phpjs.trim(wpautop(content1)).should.be.eql(expected1);
-    phpjs.trim(wpautop(content2)).should.be.eql(expected2);
+    wpautop(content1).trim().should.be.eql(expected1);
+    wpautop(content2).trim().should.be.eql(expected2);
   });
 
   it('should not add <br/> to "<select>" or "<option>" elements', function() {
     var str = 'Country: <select id="state" name="state"><option value="1">Alabama</option><option value="2">Alaska</option><option value="3">Arizona</option><option value="4">Arkansas</option><option value="5">California</option></select>';
-    phpjs.trim(wpautop(str)).should.be.eql('<p>' + str + '</p>');
+    wpautop(str).trim().should.be.eql('<p>' + str + '</p>');
   });
 
   it('should autop a blockquotes contents but not the blockquote itself', function() {
     var content  = "<blockquote>foo</blockquote>";
     var expected = "<blockquote><p>foo</p></blockquote>";
 
-    phpjs.trim(wpautop(content)).should.be.eql(expected);
+    wpautop(content).trim().should.be.eql(expected);
   });
 
   it('should not choke on an alternating set of <pre> and <div> tags', function() {
     var content  = "<div>div 1</div><pre>pre 1</pre><div>div 2</div><pre>pre 2</pre><div>div 3</div><pre>pre 3</pre><div>div 4</div><pre>pre 4</pre>";
     var expected = "<div>div 1</div>\n<pre>pre 1</pre>\n<div>div 2</div>\n<pre>pre 2</pre>\n<div>div 3</div>\n<pre>pre 3</pre>\n<div>div 4</div>\n<pre>pre 4</pre>";
 
-    phpjs.trim(wpautop(content)).should.be.eql(expected);
+    wpautop(content).trim().should.be.eql(expected);
   });
 
 });


### PR DESCRIPTION
@andymantell I've removed the dependency on `phpjs` entirely - it was only being used in the tests and mostly just for its `phpjs.trim()` function with I replaced with `String.trim()`. The only other one was on line 128, you were using `phpjs.htmlentities()`. That's a slightly less trivial one to replace - but I removed it from the test and the test still passed. Double check you're happy with that, and if not I'd suggest using the [he](https://github.com/mathiasbynens/he) library instead of phpjs.

Whilst I was there, I also added `mocha` as a devDependency so you don't have to globally install it in your `.travis.yml` file. I also updated the Travis config to include some more recent versions of `node_js`.

Finally, I removed the `mocha-jshint` devDependency since this was only being referenced in a commented out line of code in a test file (which I also removed, since it was empty except the comment). Not sure if you had been using this as a quick way to `jshint` your code, but I'd advise either setting a proper build script to do that or installing it globally. I'm happy to put that back in if I've overstepped the mark by removing it, but this felt like an easy cleanup.